### PR TITLE
Add support for Portage(in Gentoo) build system

### DIFF
--- a/corpus_descriptions_test/portage_boost.json
+++ b/corpus_descriptions_test/portage_boost.json
@@ -1,0 +1,8 @@
+{
+  "sources": [],
+  "folder_name": "boost",
+  "build_system": "portage",
+  "package_name": "boost",
+  "package_spec": "dev-libs/boost",
+  "license": "GPL-3.0-only"
+}

--- a/corpus_descriptions_test/portage_hello.json
+++ b/corpus_descriptions_test/portage_hello.json
@@ -1,0 +1,8 @@
+{
+  "sources": [],
+  "folder_name": "hello",
+  "build_system": "portage",
+  "package_name": "hello",
+  "package_spec": "app-misc/hello",
+  "license": "GPL-3.0-only"
+}

--- a/llvm_ir_dataset_utils/builders/builder.py
+++ b/llvm_ir_dataset_utils/builders/builder.py
@@ -19,6 +19,7 @@ from llvm_ir_dataset_utils.builders import (
     manual_builder,
     spack_builder,
     swift_builder,
+    portage_builder
 )
 from llvm_ir_dataset_utils.sources import source
 from llvm_ir_dataset_utils.util import file, licenses
@@ -208,6 +209,21 @@ def parse_and_build_from_description(
         corpus_description["package_name"],
         corpus_description["package_spec"],
         corpus_description["package_hash"],
+        corpus_dir,
+        threads,
+        extra_builder_arguments["buildcache_dir"],
+        build_dir,
+        cleanup,
+    )
+  elif corpus_description["build_system"] == "portage":
+    if "dependency_futures" in extra_builder_arguments:
+      dependency_futures = extra_builder_arguments["dependency_futures"]
+    else:
+      dependency_futures = []
+    build_log = portage_builder.build_package(
+        dependency_futures,
+        corpus_description["package_name"],
+        corpus_description["package_spec"],
         corpus_dir,
         threads,
         extra_builder_arguments["buildcache_dir"],

--- a/llvm_ir_dataset_utils/builders/builder.py
+++ b/llvm_ir_dataset_utils/builders/builder.py
@@ -11,16 +11,10 @@ import shutil
 
 import ray
 
-from llvm_ir_dataset_utils.builders import (
-    autoconf_builder,
-    cargo_builder,
-    cmake_builder,
-    julia_builder,
-    manual_builder,
-    spack_builder,
-    swift_builder,
-    portage_builder
-)
+from llvm_ir_dataset_utils.builders import (autoconf_builder, cargo_builder,
+                                            cmake_builder, julia_builder,
+                                            manual_builder, spack_builder,
+                                            swift_builder, portage_builder)
 from llvm_ir_dataset_utils.sources import source
 from llvm_ir_dataset_utils.util import file, licenses
 

--- a/llvm_ir_dataset_utils/builders/portage_builder.py
+++ b/llvm_ir_dataset_utils/builders/portage_builder.py
@@ -1,0 +1,161 @@
+"""Module for building and extracting bitcode from applications using Portage"""
+
+import subprocess
+import os
+import tempfile
+import logging
+import pathlib
+import shutil
+import re
+import getpass
+import ray
+
+from mlgo.corpus import extract_ir_lib
+
+from llvm_ir_dataset_utils.util import file
+from llvm_ir_dataset_utils.util import portage as portage_utils
+from llvm_ir_dataset_utils.util import extract_source_lib
+
+SPACK_GARBAGE_COLLECTION_TIMEOUT = 300
+
+BUILD_LOG_NAME = './portage_build.log'
+
+
+def get_spec_command_vector_section(spec):
+  return spec.split(' ')
+
+
+def generate_emerge_command(package_to_build, threads, build_dir):
+    config_root = os.path.join(build_dir, "/etc/portage")
+    command_vector = [
+        'emerge',  # Portage package management command
+        '--jobs={}'.format(threads),  # Set the number of jobs for parallel building
+        '--load-average={}'.format(threads),  # Set the maximum load average for parallel builds
+        '--keep-going',  # Continue with other builds even if one fails
+        '--buildpkg',  # Build binary packages, similar to Spack's build cache
+        '--binpkg-respect-use=y',  # Ensure that binary package installations respect USE flag settings
+        '--quiet-build=y',  # Reduce output during the build process
+        package_to_build  # The package to install
+    ]
+
+    # Portage does not support setting the build directory directly in the command,
+    # but this can be controlled with the PORTAGE_TMPDIR environment variable
+    # This environment variable needs to be set when calling subprocess, not here directly
+    return command_vector
+
+
+def perform_build(package_name, assembled_build_command, corpus_dir, build_dir):
+  logging.info(f"Portage building package {package_name}")
+  environment = os.environ.copy()
+  # Set DISTDIR and PORTAGE_TMPDIR to set the build directory for Portage
+  environment['DISTDIR'] = build_dir
+  environment['PORTAGE_TMPDIR'] = build_dir
+  build_log_path = os.path.join(corpus_dir, BUILD_LOG_NAME)
+  try:
+    with open(build_log_path, 'w') as build_log_file:
+      subprocess.run(
+          assembled_build_command,
+          stdout=build_log_file,
+          stderr=build_log_file,
+          check=True,
+          env=environment)
+  except subprocess.SubprocessError:
+    logging.warn(f"Failed to build portage package {package_name}")
+    return False
+  logging.info(f"Finished build portage package {package_name}")
+  return True
+
+
+def extract_ir(corpus_dir, build_dir, threads):
+  build_directory = build_dir + "/portage/"
+  if build_directory is not None:
+    current_verbosity = logging.getLogger().getEffectiveLevel()
+    logging.getLogger().setLevel(logging.ERROR)
+    objects = extract_ir_lib.load_from_directory(build_directory, corpus_dir)
+    print(objects)
+    relative_output_paths = extract_ir_lib.run_extraction(
+        objects, threads, "llvm-objcopy", None, None, ".llvmcmd", ".llvmbc")
+    print(relative_output_paths)
+    extract_ir_lib.write_corpus_manifest(None, relative_output_paths,
+                                         corpus_dir)
+    logging.getLogger().setLevel(current_verbosity)
+    extract_source_lib.copy_source(build_directory, corpus_dir)
+
+
+def cleanup(package_name, package_spec, corpus_dir, uninstall=True):
+  #TODO: Implement cleanup
+  return
+
+
+def construct_build_log(build_success, package_name):
+  return {
+      'targets': [{
+          'name': package_name,
+          'build_log': BUILD_LOG_NAME,
+          'success': build_success
+      }]
+  }
+
+def portage_add_local_mirror(build_dir, local_mirror_dir):
+    environment = os.environ.copy()
+    environment['HOME'] = build_dir
+    # Create the file:// URL for the local mirror directory
+    local_mirror_url = f"file://{local_mirror_dir}"
+    
+    # Path to the Portage make.conf file within the build directory
+    make_conf_path = os.path.join(build_dir, "etc/portage/make.conf")
+    
+    # Ensure the make.conf file exists
+    os.makedirs(os.path.dirname(make_conf_path), exist_ok=True)
+    if not os.path.exists(make_conf_path):
+        with open(make_conf_path, 'w') as file:
+            file.write("# Generated make.conf\n")
+    
+    # Read and update the make.conf file
+    with open(make_conf_path, 'r+') as file:
+        lines = file.readlines()
+        file.seek(0)
+        file.truncate()
+        found = False
+        
+        # Update the GENTOO_MIRRORS setting
+        for line in lines:
+            if line.startswith("GENTOO_MIRRORS="):
+                line = f"GENTOO_MIRRORS=\"{local_mirror_url}\"\n"
+                found = True
+            file.write(line)
+        
+        # If GENTOO_MIRRORS was not found, add a new line
+        if not found:
+            file.write(f"GENTOO_MIRRORS=\"{local_mirror_url}\"\n")
+
+def build_package(dependency_futures,
+                  package_name,
+                  package_spec,
+                  corpus_dir,
+                  threads,
+                  buildcache_dir,
+                  build_dir,
+                  cleanup_build=False):
+  dependency_futures = ray.get(dependency_futures)
+  for dependency_future in dependency_futures:
+    if dependency_future['targets'][0]['success'] != True:
+      logging.warning(
+          f'Dependency {dependency_future["targets"][0]["name"]} failed to build for package {package_name}, not building.'
+      )
+      if cleanup_build:
+        cleanup(package_name, package_spec, corpus_dir, uninstall=False)
+      return construct_build_log(False, package_name, None)
+  build_command = generate_emerge_command(package_spec, threads, build_dir)
+  build_result = perform_build(package_name, build_command, corpus_dir,
+                               build_dir)
+  if build_result:
+    extract_ir(corpus_dir, build_dir, threads)
+    # push_to_buildcache(package_spec, buildcache_dir, corpus_dir)
+    logging.warning(f'Finished building {package_name}')
+  if cleanup_build:
+    if build_result:
+      cleanup(package_name, package_spec, corpus_dir)
+    else:
+      cleanup(package_name, package_spec, corpus_dir, uninstall=False)
+  return construct_build_log(build_result, package_name)

--- a/llvm_ir_dataset_utils/builders/portage_builder.py
+++ b/llvm_ir_dataset_utils/builders/portage_builder.py
@@ -17,7 +17,6 @@ from llvm_ir_dataset_utils.util import file
 from llvm_ir_dataset_utils.util import portage as portage_utils
 from llvm_ir_dataset_utils.util import extract_source_lib
 
-
 BUILD_LOG_NAME = './portage_build.log'
 
 
@@ -73,7 +72,7 @@ def extract_ir(package_spec, corpus_dir, build_dir, threads):
   build_directory = build_dir + "/portage/"
   package_spec = package_spec + "*"
   match = glob.glob(os.path.join(build_directory, package_spec))
-  assert(len(match) == 1)
+  assert (len(match) == 1)
   package_name_with_version = os.path.basename(match[0])
   build_directory = match[0] + "/work/" + package_name_with_version
   if build_directory is not None:

--- a/llvm_ir_dataset_utils/util/portage.py
+++ b/llvm_ir_dataset_utils/util/portage.py
@@ -1,0 +1,50 @@
+"""Utilities related to portage."""
+
+import subprocess
+import os
+
+def get_compiler_version():
+  compiler_command_vector = ['clang', '--version']
+  compiler_version_process = subprocess.run(
+      compiler_command_vector,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.STDOUT,
+      check=True)
+  version_line = compiler_version_process.stdout.decode('utf-8').split('\n')[0]
+  version_line_parts = version_line.split(' ')
+  for index, version_line_part in enumerate(version_line_parts):
+    if version_line_part == 'version':
+      return version_line_parts[index + 1]
+
+def get_os_info():
+    import platform
+    return platform.system().lower()
+
+def get_portage_compiler_config():
+    compiler_version = get_compiler_version()
+    os_info = get_os_info()
+    compiler_config = (
+        f"# Compiler Configuration\n"
+        f"CFLAGS=\"-Xclang -fembed-bitcode=all\"\n"
+        f"CXXFLAGS=\"${{CFLAGS}}\"\n"
+        f"FCFLAGS=\"${{CFLAGS}}\"\n"
+        f"# Compiler: Clang {compiler_version}\n"
+        f"# Operating System: {os_info}\n"
+        "CC=\"/usr/bin/clang\"\n"
+        "CXX=\"/usr/bin/clang++\"\n"
+        "FC=\"/usr/bin/gfortran\"\n"
+        "F77=\"/usr/bin/gfortran\"\n"
+    )
+    return compiler_config
+
+def portage_setup_compiler(build_dir):
+    # Same as spack, path is variable depending upon the system.
+    # Path to the Portage make.conf file within the build directory
+    make_conf_path = os.path.join(build_dir, "/etc/portage/make.conf")
+    
+    # Ensure the directory for make.conf exists
+    os.makedirs(os.path.dirname(make_conf_path), exist_ok=True)
+    
+    # Write the compiler configuration to make.conf
+    with open(make_conf_path, 'w') as compiler_config_file:
+        compiler_config_file.writelines(get_portage_compiler_config())

--- a/llvm_ir_dataset_utils/util/portage.py
+++ b/llvm_ir_dataset_utils/util/portage.py
@@ -6,23 +6,20 @@ import os
 
 
 def get_portage_compiler_config(filename):
-    content = (
-        'COMMON_FLAGS="-O2 -pipe -Xclang -fembed-bitcode=all"\n'
-        '\n'
-        'CC="/root/ir-dataset/utils/compiler_wrapper"\n'
-        'CXX="/root/ir-dataset/utils/compiler_wrapper++"\n'
-        'CFLAGS="${COMMON_FLAGS}"\n'
-        'CXXFLAGS="${COMMON_FLAGS}"\n'
-        'FCFLAGS="${COMMON_FLAGS}"\n'
-        'FFLAGS="${COMMON_FLAGS}"\n'
-        '\n'
-        'FEATURES="noclean"\n'
-        '\n'
-        'LC_MESSAGES=C.utf8'
-    )
-    with open(filename, 'w') as file:
-        file.write(content)
-
+  content = ('COMMON_FLAGS="-O2 -pipe -Xclang -fembed-bitcode=all"\n'
+             '\n'
+             'CC="/root/ir-dataset/utils/compiler_wrapper"\n'
+             'CXX="/root/ir-dataset/utils/compiler_wrapper++"\n'
+             'CFLAGS="${COMMON_FLAGS}"\n'
+             'CXXFLAGS="${COMMON_FLAGS}"\n'
+             'FCFLAGS="${COMMON_FLAGS}"\n'
+             'FFLAGS="${COMMON_FLAGS}"\n'
+             '\n'
+             'FEATURES="noclean"\n'
+             '\n'
+             'LC_MESSAGES=C.utf8')
+  with open(filename, 'w') as file:
+    file.write(content)
 
 
 def portage_setup_compiler(build_dir):
@@ -40,6 +37,7 @@ def portage_setup_compiler(build_dir):
   shutil.rmtree(make_profile_path)
   os.symlink('/etc/portage/make.profile', make_profile_path)
   get_portage_compiler_config(make_conf_path)
+
 
 def clean_binpkg(package_spec):
   command_vector = ['rm', '-rf', '/var/cache/binpkgs/' + package_spec]

--- a/utils/compiler_wrapper.py
+++ b/utils/compiler_wrapper.py
@@ -38,6 +38,7 @@ def save_preprocessed_source(mode, compiler_arguments):
 
   run_compiler_invocation(mode, arguments_copy)
 
+
 def save_preprocessed_source_multi(mode, source_file, compiler_arguments):
   # We shouldn't fail to find the output here if the argument parsing
   # succeeded.
@@ -47,12 +48,14 @@ def save_preprocessed_source_multi(mode, source_file, compiler_arguments):
   arguments_copy[output_index] = output_path
   for arg_idx in range(len(arguments_copy)):
     for recognized_extension in RECOGNIZED_SOURCE_FILE_EXTENSIONS:
-      if arguments_copy[arg_idx].endswith(recognized_extension) and arguments_copy[arg_idx] != source_file:
-        arguments_copy[arg_idx]=''
+      if arguments_copy[arg_idx].endswith(
+          recognized_extension) and arguments_copy[arg_idx] != source_file:
+        arguments_copy[arg_idx] = ''
   arguments_copy = list(filter(None, arguments_copy))
   # Add -E to the compiler invocation to run just the preprocessor.
   arguments_copy.append('-E')
   run_compiler_invocation(mode, arguments_copy)
+
 
 def save_source(source_files, output_file, mode, compiler_arguments):
   if len(source_files) == 1:
@@ -61,7 +64,7 @@ def save_source(source_files, output_file, mode, compiler_arguments):
 
     save_preprocessed_source(mode, compiler_arguments)
     return
-  
+
   for source_file in source_files:
     new_file_name = output_file + '.source'
     shutil.copy(source_file, new_file_name)
@@ -98,7 +101,7 @@ def main(args):
     # In this case, don't copy over any files and just run the compiler
     # invocation.
     mode = parsed_arguments
-    if(len(parsed_arguments) == 1):
+    if len(parsed_arguments) == 1:
       mode = parsed_arguments[0]
     return_code = run_compiler_invocation(mode, args[1:])
     sys.exit(return_code)

--- a/utils/compiler_wrapper.py
+++ b/utils/compiler_wrapper.py
@@ -38,14 +38,35 @@ def save_preprocessed_source(mode, compiler_arguments):
 
   run_compiler_invocation(mode, arguments_copy)
 
+def save_preprocessed_source_multi(mode, source_file, compiler_arguments):
+  # We shouldn't fail to find the output here if the argument parsing
+  # succeeded.
+  output_index = compiler_arguments.index('-o') + 1
+  arguments_copy = compiler_arguments.copy()
+  output_path = source_file + '.preprocessed_source'
+  arguments_copy[output_index] = output_path
+  for arg_idx in range(len(arguments_copy)):
+    for recognized_extension in RECOGNIZED_SOURCE_FILE_EXTENSIONS:
+      if arguments_copy[arg_idx].endswith(recognized_extension) and arguments_copy[arg_idx] != source_file:
+        arguments_copy[arg_idx]=''
+  arguments_copy = list(filter(None, arguments_copy))
+  # Add -E to the compiler invocation to run just the preprocessor.
+  arguments_copy.append('-E')
+  run_compiler_invocation(mode, arguments_copy)
 
 def save_source(source_files, output_file, mode, compiler_arguments):
-  assert (len(source_files) <= 1)
+  if len(source_files) == 1:
+    new_file_name = output_file + '.source'
+    shutil.copy(source_files[0], new_file_name)
+
+    save_preprocessed_source(mode, compiler_arguments)
+    return
+  
   for source_file in source_files:
     new_file_name = output_file + '.source'
     shutil.copy(source_file, new_file_name)
 
-    save_preprocessed_source(mode, compiler_arguments)
+    save_preprocessed_source_multi(mode, source_file, compiler_arguments)
 
 
 def parse_args(arguments_split):
@@ -77,6 +98,8 @@ def main(args):
     # In this case, don't copy over any files and just run the compiler
     # invocation.
     mode = parsed_arguments
+    if(len(parsed_arguments) == 1):
+      mode = parsed_arguments[0]
     return_code = run_compiler_invocation(mode, args[1:])
     sys.exit(return_code)
 


### PR DESCRIPTION
This commit adds support for the Portage build system in the `builder.py` file. It includes the necessary code to build a package using Portage, including handling dependency futures and specifying the package name and package spec. This change allows for more flexibility in building packages with different build systems.

This commit also modifies the mechanism of generating preprocessed files.